### PR TITLE
Update httpstatuses.com to reflect current status (ahem)

### DIFF
--- a/source/projects/httpstatus.es.md
+++ b/source/projects/httpstatus.es.md
@@ -2,7 +2,7 @@
 title: httpstatuses.com
 link: https://httpstatuses.com
 tags:
-    - developer
+    - retired
     - founder
 ---
 


### PR DESCRIPTION
I have continued with the `retired` tag which is also used for minecraftwiki.net. Another one could be considered?